### PR TITLE
Update gems

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -136,7 +136,7 @@ GEM
     jbuilder (2.14.1)
       actionview (>= 7.0.0)
       activesupport (>= 7.0.0)
-    json (2.13.2)
+    json (2.15.0)
     jwt (3.1.2)
       base64
     language_server-protocol (3.17.0.5)
@@ -150,7 +150,7 @@ GEM
       net-imap
       net-pop
       net-smtp
-    marcel (1.0.4)
+    marcel (1.1.0)
     matrix (0.4.3)
     mini_mime (1.1.5)
     mini_portile2 (2.8.9)
@@ -188,8 +188,8 @@ GEM
     pp (0.6.2)
       prettyprint
     prettyprint (0.2.0)
-    prism (1.4.0)
-    propshaft (1.2.1)
+    prism (1.5.1)
+    propshaft (1.3.0)
       actionpack (>= 7.0.0)
       activesupport (>= 7.0.0)
       rack
@@ -259,7 +259,7 @@ GEM
       rubocop-ast (>= 1.46.0, < 2.0)
       ruby-progressbar (~> 1.7)
       unicode-display_width (>= 2.4.0, < 4.0)
-    rubocop-ast (1.46.0)
+    rubocop-ast (1.47.1)
       parser (>= 3.3.7.2)
       prism (~> 1.4)
     rubocop-minitest (0.38.2)
@@ -330,9 +330,9 @@ GEM
       railties (>= 7.1.0)
     tzinfo (2.0.6)
       concurrent-ruby (~> 1.0)
-    unicode-display_width (3.1.5)
-      unicode-emoji (~> 4.0, >= 4.0.4)
-    unicode-emoji (4.0.4)
+    unicode-display_width (3.2.0)
+      unicode-emoji (~> 4.1)
+    unicode-emoji (4.1.0)
     uri (1.0.3)
     useragent (0.16.11)
     vcr (6.3.1)


### PR DESCRIPTION
Bumped versions for several gems, including json, marcel, prism, propshaft, rubocop-ast, unicode-display_width, and unicode-emoji. This updates dependencies to their latest compatible versions for improved features and bug fixes.
Bump Rails and related gems (actioncable, actionmailbox, actionmailer, actionpack, actiontext, actionview, activejob, activemodel, activerecord, activestorage, activesupport, railties) from 8.0.2.1 to 8.0.3. Also update nokogiri, puma, regexp_parser, rexml, sqlite3, and add tsort dependency.